### PR TITLE
delete Front-end Week at (Repositórios da Front-End Brasil)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,4 @@ para adicionar e entrar em contato.
 - [Doe um Livro](https://github.com/frontendbr/doe-um-livro)
 - [Poste Mais!](https://github.com/frontendbr/poste-mais)
 - [Open Source](https://github.com/frontendbr/open-source)
-- [Front-End Week](https://github.com/frontendbr/frontendweek)
 - [Sugestões](https://github.com/frontendbr/sugestoes)


### PR DESCRIPTION
Tirei o Repositório Front-end Week mencionado no README.md na seção Repositórios da Front-End Brasil porque não existe.