### PR TITLE
ci: update actions to auto-label 

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,12 +1,14 @@
 name: Labeling new issue
+
 on:
   issues:
-      types: ['opened']
+      types: ['opened', 'edited']
+      
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: Renato66/auto-label@v2
+      - uses: Renato66/auto-label@v2.3.0
         with:
           repo-token: ${{ secrets.ACTIONS }}
           labels-not-allowed: '["Stale","Pendente de informações","Falta de informações"]'


### PR DESCRIPTION
- Atualizado versão da action para a mais recente (2.3.0).
- Executa a action na criação e na edição das issues.